### PR TITLE
[SGP-22261] feat: make Drum Django 3-compatible

### DIFF
--- a/drum/links/models.py
+++ b/drum/links/models.py
@@ -12,11 +12,11 @@ except ImportError:
     from urlparse import urlparse
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
+from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 
 from mezzanine.accounts import get_profile_model

--- a/drum/links/models.py
+++ b/drum/links/models.py
@@ -66,7 +66,7 @@ class Link(Displayable, Ownable):
 @python_2_unicode_compatible
 class Profile(models.Model):
 
-    user = models.OneToOneField(USER_MODEL)
+    user = models.OneToOneField(USER_MODEL, on_delete=models.CASCADE)
     website = models.URLField(blank=True)
     bio = models.TextField(blank=True)
     karma = models.IntegerField(default=0, editable=False)


### PR DESCRIPTION
BREAKING CHANGE: Remove Django 1.X compatibility

This PR adds compatibility with Django 3.X, in preparation for the upgrade to Django 3.

### Manual QA

1. Checkout the branch from https://github.com/startupgrind/Platform/pull/10810, which pins Drum to this commit.
1. Run `BEVY_VARIATION=demo docker-compose -f docker-compose-lts.yml up` (you may also need to add the `--build` flag). When the app starts, you should not see any errors relating to this package.